### PR TITLE
added bash snippet to install dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 ## Getting Started
 
-First, run the development server:
+First, install dependencies:
+
+```bash
+npm install
+# or
+yarn install
+```
+
+Then, run the development server:
 
 ```bash
 npm run dev


### PR DESCRIPTION
it may seem obvious that dependencies need to be installed after cloning but it seems worthwhile to explicitly outline every step, including running ```npm install``` to install dependencies. just in case there are some glossy-eyed newbs who get stuck before even getting started!