### PR TITLE
no viewport meta tag needed

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -47,7 +47,6 @@ export default function Home() {
     <div className={styles.container}>
       <Head>
         <title>Replicate + Next.js</title>
-        <meta name="viewport" content="initial-scale=1.0, width=device-width" />
       </Head>
 
       <p>


### PR DESCRIPTION
`next/head` adds this meta tag automatically

See https://github.com/vercel/next.js/pull/44454

Thanks to @leerob for pointing this out. 🙇🏼 