### PR TITLE
prefer `remotePatterns` over `domains` for images

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,16 @@
 const nextConfig = {
   reactStrictMode: true,
   images: {
-    domains: ["replicate.com", "replicate.delivery"],
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "replicate.com",
+      },
+      {
+        protocol: "https",
+        hostname: "replicate.delivery",
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
From https://nextjs.org/docs/api-reference/next/image#remote-patterns

> We recommend using [remotePatterns](https://nextjs.org/docs/api-reference/next/image#remote-patterns) instead so you can restrict protocol and pathname.

Thanks to @leerob for pointing this out. 🔒 