### PR TITLE
Replace @next/font with next/font

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "test": "npm run lint && npm run build"
   },
   "dependencies": {
-    "@next/font": "13.4.19",
     "eslint": "8.49.0",
     "eslint-config-next": "13.0.7",
     "next": "13.4.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -127,11 +127,6 @@
   dependencies:
     glob "7.1.7"
 
-"@next/font@13.4.19":
-  version "13.4.19"
-  resolved "https://registry.yarnpkg.com/@next/font/-/font-13.4.19.tgz#2b69aee760a3bbabf54873f80ae6d4b09b35d133"
-  integrity sha512-yOuSRYfqksWcaG/sATr1/DEGvvI8gnmAAnQCCZ0+L9p4Pio3/DMu71J56YHh9Hz84LDN4tMVzuux0ssCuM50sA==
-
 "@next/swc-darwin-arm64@13.4.19":
   version "13.4.19"
   resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.19.tgz#77ad462b5ced4efdc26cb5a0053968d2c7dac1b6"


### PR DESCRIPTION
Deal with the following warning:
```
⚠ Your project has `@next/font` installed as a dependency, please use the built-in `next/font` instead. The `@next/font` package will be removed in Next.js 14. You can migrate by running `npx @next/codemod@latest built-in-next-font .`. Read more: https://nextjs.org/docs/messages/built-in-next-font
```