### PR TITLE
Prevent response caching in Next.js

### DIFF
--- a/app/api/predictions/[id]/route.js
+++ b/app/api/predictions/[id]/route.js
@@ -5,6 +5,12 @@ const replicate = new Replicate({
   auth: process.env.REPLICATE_API_TOKEN,
 });
 
+// Prevent Next.js / Vercel from caching responses
+// See https://github.com/replicate/replicate-javascript/issues/136#issuecomment-1728053102
+replicate.fetch = (url, options) => {
+  return fetch(url, { ...options, cache: "no-store" });
+};
+
 export async function GET(request, {params}) {
   const { id } = params;
   const prediction = await replicate.predictions.get(id);

--- a/app/api/predictions/[id]/route.js
+++ b/app/api/predictions/[id]/route.js
@@ -8,7 +8,7 @@ const replicate = new Replicate({
 // Prevent Next.js / Vercel from caching responses
 // See https://github.com/replicate/replicate-javascript/issues/136#issuecomment-1728053102
 replicate.fetch = (url, options) => {
-  return fetch(url, { ...options, cache: "no-store" });
+  return fetch(url, { cache: "no-store", ...options });
 };
 
 export async function GET(request, {params}) {

--- a/app/api/predictions/route.js
+++ b/app/api/predictions/route.js
@@ -5,6 +5,12 @@ const replicate = new Replicate({
   auth: process.env.REPLICATE_API_TOKEN,
 });
 
+// Prevent Next.js / Vercel from caching responses
+// See https://github.com/replicate/replicate-javascript/issues/136#issuecomment-1728053102
+replicate.fetch = (url, options) => {
+  return fetch(url, { ...options, cache: "no-store" });
+};
+
 // In production and preview deployments (on Vercel), the VERCEL_URL environment variable is set.
 // In development (on your local machine), the NGROK_HOST environment variable is set.
 const WEBHOOK_HOST = process.env.VERCEL_URL


### PR DESCRIPTION
This PR prevents Next.js / Vercel from caching responses from Replicate's API.

See https://github.com/replicate/replicate-javascript/issues/136#issuecomment-1728053102